### PR TITLE
[FEAT] : ⚙️ FriendEdit에서 프로필사진 편집 후 MainActivity 프로필사진과 연동

### DIFF
--- a/app/src/main/java/com/android/iz4/FriendEdit.kt
+++ b/app/src/main/java/com/android/iz4/FriendEdit.kt
@@ -18,7 +18,8 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.squareup.picasso.Picasso
 
 class FriendEdit : AppCompatActivity() {
-        private lateinit var addimg:LinearLayout
+    private lateinit var addimg: LinearLayout
+    private var imageUrl: String? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_friendedit)
@@ -34,14 +35,16 @@ class FriendEdit : AppCompatActivity() {
         val editstatus = findViewById<EditText>(R.id.feStatusEditView)
         val edittitle = findViewById<EditText>(R.id.feTitleEditView)
         val editcontent = findViewById<EditText>(R.id.feContentEditView)
+        val editimgView = findViewById<ImageView>(R.id.feprofile)
 
         val index = intent.getIntExtra("index", -1)
         val fenick = intent.getStringExtra("fenick") ?: ""
         val fename = intent.getStringExtra("fename") ?: ""
         val fembti = intent.getStringExtra("fembti") ?: ""
         val festatus = intent.getStringExtra("festatus") ?: ""
-        val title = intent.getStringExtra("fetitle") ?:""
-        val content = intent.getStringExtra("fecontent") ?:""
+        val title = intent.getStringExtra("fetitle") ?: ""
+        val content = intent.getStringExtra("fecontent") ?: ""
+        val imgbtn = intent.getStringExtra("imgBtn")?:""
 
         editnick.setText(fenick)
         editname.setText(fename)
@@ -50,10 +53,16 @@ class FriendEdit : AppCompatActivity() {
         edittitle.setText(title)
         editcontent.setText(content)
 
+        if (imageUrl.isNullOrEmpty() && !imgbtn.isEmpty()) {
+            imageUrl = imgbtn
+            Picasso.get().load(imageUrl).error(R.drawable.odung_smile).into(editimgView)
+        }
+
+
         addimg = findViewById(R.id.feaddimg)
         val addButton = findViewById<FloatingActionButton>(R.id.febtntitle)
         val viewList = arrayListOf<View>()
-        addButton.setOnClickListener{
+        addButton.setOnClickListener {
             val inflater = LayoutInflater.from(this)
             val item = inflater.inflate(R.layout.additem, addimg, false)
             addimg.addView(item)
@@ -73,31 +82,33 @@ class FriendEdit : AppCompatActivity() {
                 val title1 = it.findViewById<EditText>(R.id.feTitleEditView)
                 val imgView1 = it.findViewById<ImageView>(R.id.feaddimgView)
                 val content1 = it.findViewById<EditText>(R.id.feContentEditView)
-                Log.d("view",title1.text.toString())
+                Log.d("view", title1.text.toString())
             }
-            if(!nick.isEmpty() && !name.isEmpty() && !mbti.isEmpty() && !status.isEmpty()){
+            if (!nick.isEmpty() && !name.isEmpty() && !mbti.isEmpty() && !status.isEmpty()) {
 
                 val intent = Intent(this, MainActivity::class.java)
                 intent.putExtra("index", index)
-                intent.putExtra("inputName",name)
-                intent.putExtra("inputNick",nick)
-                intent.putExtra("inputMbti",mbti)
-                intent.putExtra("inputStatus",status)
-                intent.putExtra("inputTitle",title)
-                intent.putExtra("inputContent",content)
+                intent.putExtra("inputName", name)
+                intent.putExtra("inputNick", nick)
+                intent.putExtra("inputMbti", mbti)
+                intent.putExtra("inputStatus", status)
+                intent.putExtra("inputTitle", title)
+                intent.putExtra("inputContent", content)
+                intent.putExtra("imageUrl", imageUrl)
 
-                setResult(RESULT_OK,intent)
+                setResult(RESULT_OK, intent)
                 finish()
-            }else {
-                Toast.makeText(this,"입력되지 않은 정보가 있습니다.", Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(this, "입력되지 않은 정보가 있습니다.", Toast.LENGTH_SHORT).show()
             }
         }
         val imgclick = findViewById<ImageView>(R.id.feprofile)
         imgclick.setOnClickListener {
-           dialog(imgclick)
+            dialog(imgclick)
         }
     }
-    private fun dialog(imgView: ImageView){
+
+    private fun dialog(imgView: ImageView) {
         val builder = AlertDialog.Builder(this)
         builder.setTitle("URL을 입력 하세요.")
 
@@ -105,8 +116,8 @@ class FriendEdit : AppCompatActivity() {
         builder.setView(inputEditText)
 
         builder.setPositiveButton("확인") { dialog, which ->
-            val imageUrl = inputEditText.text.toString()
-            if (imageUrl.isNotEmpty()) {
+            imageUrl = inputEditText.text.toString()
+            if (!imageUrl.isNullOrEmpty()) {
                 Picasso.get().load(imageUrl).error(R.drawable.odung_smile).into(imgView)
             }
         }
@@ -115,6 +126,7 @@ class FriendEdit : AppCompatActivity() {
         val dialog = builder.create()
         dialog.show()
     }
+
     override fun onStart() {
         super.onStart()
         Log.d("Lifecycle", "onStart")

--- a/app/src/main/java/com/android/iz4/MainActivity.kt
+++ b/app/src/main/java/com/android/iz4/MainActivity.kt
@@ -13,11 +13,13 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.squareup.picasso.Picasso
 
 class MainActivity : AppCompatActivity() {
     lateinit var friendresult: ActivityResultLauncher<Intent>
     private lateinit var imgadd: LinearLayout
     private lateinit var addmemberbtn: FloatingActionButton
+    private var imageUrl: String = ""
     companion object {
         val nickList = mutableListOf("aaa", "bbb", "ccc", "ddd","")
         val nameList = mutableListOf("aaa", "bbb", "ccc", "ddd","")
@@ -25,6 +27,7 @@ class MainActivity : AppCompatActivity() {
         val statusList = mutableListOf("aaa", "bbb", "ccc", "ddd","")
         val titleList = mutableListOf("","","","","")
         val contentList = mutableListOf("","","","","")
+
     }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -91,6 +94,12 @@ class MainActivity : AppCompatActivity() {
                         statusList[index] = data.getStringExtra("inputStatus") ?: ""
                         titleList[index] = data.getStringExtra("inputTitle")?:""
                         contentList[index] = data.getStringExtra("inputContent") ?:""
+                        imageUrl = data.getStringExtra("imageUrl") ?:""
+
+                        if (imageUrl.isNotEmpty()) {
+                            val imgBtn = imgBtnList[index]
+                            Picasso.get().load(imageUrl).error(R.drawable.odung_smile).into(imgBtn)
+                        }
 
                         nickList.add(nickList[index] ?: "")
                         nameList.add(nameList[index] ?: "")
@@ -117,6 +126,7 @@ class MainActivity : AppCompatActivity() {
                     intent.putExtra("festatus", statusList[index])
                     intent.putExtra("fetitle", titleList[index])
                     intent.putExtra("fecontent", contentList[index])
+                    intent.putExtra("imgBtn",imageUrl)
                     friendresult.launch(intent)
                     overridePendingTransition(R.anim.animation_in, R.anim.animation_out)
                 }


### PR DESCRIPTION
[FEAT] : ⚙️
1. FriendEdit에서 프로필사진변경한 후 저장버튼을 누르면
2. MainActivity에서 FriendEdit로 들어갈떄 클릭했던 이미지버튼의 이미지 역시 FriendEdit에서 변경한 이미지로 바뀜
3. 다시 FriendEdit로 들어가면 변경했던 이미지가 그대로 유지됨.