### PR TITLE
FIX] : 🔧 MainActivity, FriendEdit 프로필사진 해결완료

### DIFF
--- a/app/src/main/java/com/android/iz4/FriendEdit.kt
+++ b/app/src/main/java/com/android/iz4/FriendEdit.kt
@@ -25,6 +25,7 @@ class FriendEdit : AppCompatActivity() {
         setContentView(R.layout.activity_friendedit)
         Log.d("Lifecycle", "onCreate")
 
+
         val febtnback = findViewById<ImageButton>(R.id.febackbtn)
         febtnback.setOnClickListener {
             finish()
@@ -44,7 +45,7 @@ class FriendEdit : AppCompatActivity() {
         val festatus = intent.getStringExtra("festatus") ?: ""
         val title = intent.getStringExtra("fetitle") ?: ""
         val content = intent.getStringExtra("fecontent") ?: ""
-        val imgbtn = intent.getStringExtra("imgBtn")?:""
+        imageUrl = intent.getStringExtra("imgBtn") ?: ""
 
         editnick.setText(fenick)
         editname.setText(fename)
@@ -53,10 +54,16 @@ class FriendEdit : AppCompatActivity() {
         edittitle.setText(title)
         editcontent.setText(content)
 
-        if (imageUrl.isNullOrEmpty() && !imgbtn.isEmpty()) {
-            imageUrl = imgbtn
+    if (!imageUrl.isNullOrEmpty()) {
+        val resourceId = resources.getIdentifier(imageUrl, "drawable", packageName)
+        if (resourceId != 0) {
+            Picasso.get().load(resourceId).error(R.drawable.question).into(editimgView)
+        } else {
             Picasso.get().load(imageUrl).error(R.drawable.question).into(editimgView)
         }
+    } else {
+        editimgView.setImageResource(R.drawable.question)
+    }
 
         addimg = findViewById(R.id.feaddimg)
         val addButton = findViewById<FloatingActionButton>(R.id.febtntitle)

--- a/app/src/main/java/com/android/iz4/MainActivity.kt
+++ b/app/src/main/java/com/android/iz4/MainActivity.kt
@@ -20,7 +20,6 @@ class MainActivity : AppCompatActivity() {
     lateinit var friendresult: ActivityResultLauncher<Intent>
     private lateinit var imgadd: LinearLayout
     private lateinit var addmemberbtn: FloatingActionButton
-    private var imageUrl: String = ""
     companion object {
         val nickList = mutableListOf("팀원", "팀원", "팀원", "팀장","")
         val nameList = mutableListOf("조병현", "장재원", "황진주", "박성수","")
@@ -28,17 +27,11 @@ class MainActivity : AppCompatActivity() {
         val statusList = mutableListOf("왈랄랄루", "화이팅!", "안녕하세요!", "잘 부탁드려요!","")
         val titleList = mutableListOf("","","","","")
         val contentList = mutableListOf("","","","","")
-
+        val imageUrlList = mutableListOf("character2","character7","character11","character1","")
     }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        val communication = findViewById<LinearLayout>(R.id.communication)
-
-
-
-
         val imgBtnList = mutableListOf<ImageButton>(
             findViewById(R.id.mimgbtn1),
             findViewById(R.id.mimgbtn2),
@@ -95,20 +88,20 @@ class MainActivity : AppCompatActivity() {
                         statusList[index] = data.getStringExtra("inputStatus") ?: ""
                         titleList[index] = data.getStringExtra("inputTitle")?:""
                         contentList[index] = data.getStringExtra("inputContent") ?:""
-                        imageUrl = data.getStringExtra("imageUrl") ?:""
-
-                        if (imageUrl.isNotEmpty()) {
+                        imageUrlList[index] = data.getStringExtra("imageUrl") ?:""
+                        Log.d("MainActivity imageUrlList",imageUrlList[index] )
+                        if (imageUrlList[index].isNotEmpty()) {
                             val imgBtn = imgBtnList[index]
                             val commu_img1 = findViewById<ImageView>(R.id.commu_img1)
                             val commu_img2 = findViewById<ImageView>(R.id.commu_img2)
                             val commu_name1 = findViewById<EditText>(R.id.commu_name1)
                             val commu_name2 = findViewById<EditText>(R.id.commu_name2)
-                            Picasso.get().load(imageUrl).error(R.drawable.question).into(imgBtn)
+                            Picasso.get().load(imageUrlList[index]).error(R.drawable.question).into(imgBtn)
                             if (index == 0) {
-                                Picasso.get().load(imageUrl).error(R.drawable.question).into(commu_img1)
+                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question).into(commu_img1)
                                 commu_name1.setText(nameList[index])
                             } else if (index == 1) {
-                                Picasso.get().load(imageUrl).error(R.drawable.question).into(commu_img2)
+                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question).into(commu_img2)
                                 commu_name2.setText(nameList[index])
                             }
                         }
@@ -138,7 +131,8 @@ class MainActivity : AppCompatActivity() {
                     intent.putExtra("festatus", statusList[index])
                     intent.putExtra("fetitle", titleList[index])
                     intent.putExtra("fecontent", contentList[index])
-                    intent.putExtra("imgBtn",imageUrl)
+                    intent.putExtra("imgBtn",imageUrlList[index])
+                    Log.d("fromMainActivity imageUrlList", nickList[index])
                     friendresult.launch(intent)
                     overridePendingTransition(R.anim.animation_in, R.anim.animation_out)
                 }


### PR DESCRIPTION
FIX] : 🔧 MainActivity, FriendEdit 
1.양쪽 왔다갔다 할때 프로필 사진 출력
2.초기 사진도 출력됨
3.프로필 사진 수정 기능 구현