### PR TITLE
[FIX] : 🐛 이미지를 수정하지않고 저장했을때 error이미지가 출력되던부분 수정

### DIFF
--- a/app/src/main/java/com/android/iz4/FriendEdit.kt
+++ b/app/src/main/java/com/android/iz4/FriendEdit.kt
@@ -55,16 +55,16 @@ class FriendEdit : AppCompatActivity() {
         edittitle.setText(title)
         editcontent.setText(content)
 
-    if (!imageUrl.isNullOrEmpty()) {
-        val resourceId = resources.getIdentifier(imageUrl, "drawable", packageName)
-        if (resourceId != 0) {
-            Picasso.get().load(resourceId).error(R.drawable.question).into(editimgView)
+        if (imageUrl.isNullOrEmpty()) {
+            editimgView.setImageResource(R.drawable.question)
         } else {
-            Picasso.get().load(imageUrl).error(R.drawable.question).into(editimgView)
+            val resourceId = resources.getIdentifier(imageUrl, "drawable", packageName)
+            if (resourceId != 0) {
+                Picasso.get().load(resourceId).error(R.drawable.question).into(editimgView)
+            } else {
+                Picasso.get().load(imageUrl).error(R.drawable.question).into(editimgView)
+            }
         }
-    } else {
-        editimgView.setImageResource(R.drawable.question)
-    }
 
         addimg = findViewById(R.id.feaddimg)
         val addButton = findViewById<FloatingActionButton>(R.id.febtntitle)
@@ -101,7 +101,11 @@ class FriendEdit : AppCompatActivity() {
                 intent.putExtra("inputStatus", status)
                 intent.putExtra("inputTitle", title)
                 intent.putExtra("inputContent", content)
-                intent.putExtra("imageUrl", imageUrl)
+                if (imageUrl != null && imageUrl!!.isNotEmpty()) {
+                    intent.putExtra("imageUrl", imageUrl)
+                }
+
+
 
                 setResult(RESULT_OK, intent)
                 finish()

--- a/app/src/main/java/com/android/iz4/MainActivity.kt
+++ b/app/src/main/java/com/android/iz4/MainActivity.kt
@@ -140,8 +140,9 @@ class MainActivity : AppCompatActivity() {
                         mbtiList[index] = data.getStringExtra("inputMbti") ?: ""
                         statusList[index] = data.getStringExtra("inputStatus") ?: ""
                         imageUrlList[index] = data.getStringExtra("imageUrl") ?: ""
-                        Log.d("MainActivity imageUrlList", imageUrlList[index])
-                        if (imageUrlList[index].isNotEmpty()) {
+
+                        Log.d("MainActivity imageUrlList", "수정없이 저장버튼 눌렀을때 ${imageUrlList[index]}")
+                        if (imageUrlList[index].isNotEmpty() &&!imageUrlList[index].startsWith("character")) {
                             val imgBtn = imgBtnList[index]
                             val commu_img1 = findViewById<ImageView>(R.id.commu_img1)
                             val commu_img2 = findViewById<ImageView>(R.id.commu_img2)
@@ -152,17 +153,14 @@ class MainActivity : AppCompatActivity() {
                             Picasso.get().load(imageUrlList[index]).error(R.drawable.question)
                                 .into(imgBtn)
                             if (index == 0) {
-                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question)
-                                    .into(commu_img1)
+                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question).into(commu_img1)
                                 Log.d("MainActivityname", nameList[0])
                                 commu_name1.setText(nameList[index])
                             } else if (index == 1) {
-                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question)
-                                    .into(commu_img2)
+                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question).into(commu_img2)
                                 commu_name2.setText(nameList[index])
-                            }else if (index == 2) {
-                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question)
-                                    .into(commu_img3)
+                            } else if (index == 2) {
+                                Picasso.get().load(imageUrlList[index]).error(R.drawable.question).into(commu_img3)
                                 commu_name3.setText(nameList[index])
                             }
                         }


### PR DESCRIPTION
1. FriendEdit에서 이미지를 변경하지않고 저장했을때 MainActivity에서 error이미지가 출력되던부분 수정
2. 마찬가지로 다시 FriendEdit으로 돌아갔을때 error이미지가 출력되던부분 수정